### PR TITLE
Title: Doc - Improve  commit messages

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,12 @@
+########50 characters############################
+Title: (fix, chore, docs, refactor, feat)
+########72 characters##################################################
+
+Why:
+
+What:
+
+How: (list of changes):
+
+#  Note:
+#  Special instructions, testing steps, rule impact, performance impact 

--- a/doc/CSA-UserManual.md
+++ b/doc/CSA-UserManual.md
@@ -148,6 +148,16 @@ Set ulimit to 20000
 
 4. Reboot your machine
 
+### Contributor's guidelines
+
+sStandard practices for code contribution are listed in this section.
+
+1. Commit messages. A `.gitmessage` file in this repo contains the standard commit message template that was implemented 08/24/2020. Please use this template for all commit messages. DO NOT use `git -m` from the command line. Copy  the `.gitmessage` to your `HOME` directory. Then run the following command:
+
+```bash
+git config --global commit.template ~/.gitmessage
+```
+
 ### Getting help from `csa`
 
 `csa` has several major operating modes with thier own associated commands. You can see a list of the command by using `CSA help`


### PR DESCRIPTION
Why: Improve detail and consistency in commit messages

What: Implement .gitmessage as a template for commit messages

How: (list of changes):
1. Create .gitmessage template
2. Add .gitmessage file to repo
3. Add instructions for use to documenation